### PR TITLE
feat: connect FE to activities endpoint to log activities when clicked

### DIFF
--- a/mood_boost_fe/src/App.jsx
+++ b/mood_boost_fe/src/App.jsx
@@ -6,17 +6,43 @@ import JokePage from './JokePage/JokePage';
 import BreathingPage from './BreathingPage/BreathingPage';
 import HomePage from './HomePage/HomePage';
 import UserProfile from './UserProfile/UserProfile'
+import { useState } from 'react';
 
 function App() {
+  const [user, setUser] = useState(19)
+
+  function logUserActivity(userId, activityId) {
+    fetch(`http://localhost:5000/api/v1/users/${userId}/activities`, {
+      method: 'POST',
+      body: JSON.stringify({
+        activity_id: activityId
+      }),
+      headers: {
+        'Content-Type': 'application/json'
+        }
+    })
+      .then(async (response) => {
+        console.log(response)
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw errorData;
+      }
+      return response.json()
+      })
+        .catch((error) => {
+          console.log(error)
+      })
+  }
+
   return (
     <>
-      < NavBar />
+      < NavBar setUser={setUser}/>
       <div className="page-content">
       <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/quote" element={<QuotePage />} />
-        <Route path="/joke" element={<JokePage />} />
-        <Route path="/breathing" element={<BreathingPage />} />
+        <Route path="/" element={<HomePage />}/>
+        <Route path="/quote" element={<QuotePage user={user} logUserActivity={logUserActivity}/>} />
+        <Route path="/joke" element={<JokePage user={user} logUserActivity={logUserActivity}/>} />
+        <Route path="/breathing" element={<BreathingPage user={user} logUserActivity={logUserActivity}/>} />
         <Route path="/user" element={<UserProfile />} />
       </Routes>
       </div>

--- a/mood_boost_fe/src/BreathingPage/BreathingPage.jsx
+++ b/mood_boost_fe/src/BreathingPage/BreathingPage.jsx
@@ -3,8 +3,12 @@ import "./BreathingPage.css";
 import { useState } from "react";
 
 
-function BreathingPage() {
+function BreathingPage({user, logUserActivity}) {
   const [isBreathing, setIsBreathing] = useState(false);
+
+  function handleClick() {
+    logUserActivity(user, 6)
+  }
 
   const handleStartBreathing = () => {
     setIsBreathing(true);
@@ -16,7 +20,10 @@ function BreathingPage() {
             <FloatingCircles class="background"/>
             {!isBreathing && (
                 <button id="start-button" classname="start-button"
-               onClick={handleStartBreathing}
+                onClick={() => {
+                  handleStartBreathing()
+                  handleClick()
+                 }}
                >Start Breathing Exercise</button>
             )}
               {isBreathing && (

--- a/mood_boost_fe/src/JokePage/JokePage.jsx
+++ b/mood_boost_fe/src/JokePage/JokePage.jsx
@@ -1,10 +1,13 @@
 import './JokePage.css';
-import { Link } from 'react-router-dom';
 import { useState, useEffect }  from 'react';
 
-function JokePage({joke}) {
+function JokePage({joke, user, logUserActivity}) {
   const [currentJoke, setJoke] = useState(null);
   const [error, setError] = useState(null);
+
+  function handleClick() {
+    logUserActivity(user, 4)
+  }
 
   useEffect(() => {
     getjoke()
@@ -41,7 +44,12 @@ function JokePage({joke}) {
           <section className="joke-area">
             <h3>{currentJoke}</h3>
           </section> 
-                <button className='get-joke' aria-label="get a joke" onClick={() => getjoke()}>
+                <button className='get-joke' aria-label="get a joke" onClick={() => {
+                  getjoke()
+                  handleClick()
+                }
+                }
+                >
                   Tell Me A Joke
                 </button>
         </div>

--- a/mood_boost_fe/src/Modal/Modal.jsx
+++ b/mood_boost_fe/src/Modal/Modal.jsx
@@ -3,7 +3,7 @@ import './Modal.css'
 import { useState, useEffect } from 'react';
 import validator from 'validator';
 
-function Modal({modalOpen, onClose, resetToSignIn, onLoginSuccess}) {
+function Modal({modalOpen, onClose, resetToSignIn, onLoginSuccess, setUser}) {
   const [createAccount, setCreateAccount] = useState(false) 
   const [first_name, setFirstname] = useState('')
   const [username, setUserName] = useState('')
@@ -14,7 +14,7 @@ function Modal({modalOpen, onClose, resetToSignIn, onLoginSuccess}) {
   const [successMessage, setSuccessMessage] = useState('')
 
   function createNewUser() {
-    const endpoint = createAccount ? 'https://mood-boost-be.onrender.com/api/v1/users' : 'https://mood-boost-be.onrender.com/api/v1/sessions'
+    const endpoint = createAccount ? 'http://localhost:5000/api/v1/users' : 'http://localhost:5000/api/v1/sessions'
 
     const body = createAccount ? JSON.stringify({ user: { first_name, username, password, email, password_confirmation }}) : JSON.stringify({ username, password })
 
@@ -32,14 +32,17 @@ function Modal({modalOpen, onClose, resetToSignIn, onLoginSuccess}) {
       }
       return response.json()
       })
-        .then(() => {
-          setSuccessMessage(createAccount ? 'User created successfully' : 'You are logged in')
+        .then((data) => {
+          if (data.data.id) {
+            const userId = data.data.id
+            setUser(userId)
+          }
+          setSuccessMessage(createAccount ? 'User created successfully. You are logged in.' : 'You are logged in')
           setErrorMessage('')
           onLoginSuccess();
           onClose();
       })
         .catch((error) => {
-          console.log(error.errors)
           if (error.errors && error.errors[0]?.detail) {
             setErrorMessage(error.errors[0].detail)
             setSuccessMessage('')

--- a/mood_boost_fe/src/NavBar/NavBar.jsx
+++ b/mood_boost_fe/src/NavBar/NavBar.jsx
@@ -6,7 +6,7 @@ import Modal from '../Modal/Modal';
 import { useState, useEffect } from 'react';
 import { NavLink } from 'react-router-dom';
 
-function NavBar() {
+function NavBar({user, setUser}) {
   const [modalOpen, setModalOpen] = useState(false)
   const [userLoggedIn, setUserLoggedIn] = useState(false)
 
@@ -65,6 +65,8 @@ function NavBar() {
          onClose={handleCloseModal} 
          resetToSignIn={modalOpen}
          onLoginSuccess={() => setUserLoggedIn(true)}
+         user={user}
+         setUser={setUser}
           />
       </div>
     )

--- a/mood_boost_fe/src/QuotePage/QuotePage.jsx
+++ b/mood_boost_fe/src/QuotePage/QuotePage.jsx
@@ -1,9 +1,12 @@
 import "./QuotePage.css";
-import { Link } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 
-function QuotePage() {
+function QuotePage({user, logUserActivity}) {
   const [quote, setQuote] = useState(null)
+
+  function handleClick() {
+    logUserActivity(user, 5)
+  }
 
   function fetchQuote() {
     fetch('https://api.realinspire.tech/v1/quotes/random')
@@ -38,7 +41,11 @@ function QuotePage() {
               <span id="quote-content">{quote.content}</span>
               <span id="quote-author">{quote.author}</span>
             </h2>
-            <button className="new-quote" onClick={fetchQuote}>Generate New Quote</button>
+            <button className="new-quote" onClick={() => {
+              fetchQuote()
+              handleClick()
+            }}>
+            Generate New Quote</button>
           </div>
         </>
       ) : (


### PR DESCRIPTION
This PR adds a logUserActivity function to App.js, which is passed as a prop to each of the activity pages. When a user interacts with an activity page, a post call is made to the activities endpoint, which logs the user activity.

**Note** Endpoints are currently directed at localhost:5000, so you'll need to run the BE server using rails s -p 5000 to test the endpoints. 