### PR TITLE
refactor logout to use login/create account button

### DIFF
--- a/mood_boost_fe/src/App.jsx
+++ b/mood_boost_fe/src/App.jsx
@@ -36,7 +36,7 @@ function App() {
 
   return (
     <>
-      < NavBar setUser={setUser}/>
+      < NavBar user={user} setUser={setUser}/>
       <div className="page-content">
       <Routes>
         <Route path="/" element={<HomePage />}/>

--- a/mood_boost_fe/src/Modal/Modal.jsx
+++ b/mood_boost_fe/src/Modal/Modal.jsx
@@ -30,16 +30,17 @@ function Modal({modalOpen, onClose, resetToSignIn, onLoginSuccess, setUser}) {
           const errorData = await response.json();
           throw errorData;
       }
+      console.log(response)
       return response.json()
       })
         .then((data) => {
-          if (data.data.id) {
-            const userId = data.data.id
-            setUser(userId)
-          }
+          const userId = data.data.id
+          const userUserName = data.data.attributes.username
+          setUser(userId)
+          setUserName(userUserName)
+          onLoginSuccess(userId, userUserName)
           setSuccessMessage(createAccount ? 'User created successfully. You are logged in.' : 'You are logged in')
           setErrorMessage('')
-          onLoginSuccess();
           onClose();
       })
         .catch((error) => {

--- a/mood_boost_fe/src/NavBar/NavBar.jsx
+++ b/mood_boost_fe/src/NavBar/NavBar.jsx
@@ -8,7 +8,7 @@ import { NavLink } from 'react-router-dom';
 
 function NavBar({user, setUser}) {
   const [modalOpen, setModalOpen] = useState(false)
-  const [userLoggedIn, setUserLoggedIn] = useState(false)
+  const [username, setUserName] = useState('')
 
   useEffect(() => {
     const pageContent = document.querySelector('.page-content')
@@ -30,8 +30,14 @@ function NavBar({user, setUser}) {
   }
 
   function handleLogout() {
-    setUserLoggedIn(false);
+    setUser(null)
+    setUserName('')
     console.log("User Logged Out")
+  }
+
+  function handleLoginSuccess(userId, userUserName) {
+    setUser(userId)
+    setUserName(userUserName)
   }
 
     return (
@@ -51,22 +57,30 @@ function NavBar({user, setUser}) {
               </ul>
             </li>
           </ul>
-          {userLoggedIn ? (
-          <button className="logout" onClick={handleLogout}>
-            <LogOut className="logout-icon" />Logout
+          <button 
+            className="login" 
+            onClick={user ? handleLogout : handleOpenModal}
+            >
+              {user ? (
+              <div>
+                <LogOut className="logout-icon" />
+                Logged in as {username}. Logout 
+              </div>
+              ) : (
+                <div>
+                  <LogIn className="login-icon" />
+                  Login/Register
+                  </div>
+              )}
           </button>
-        ) : (
-          <button className="login" onClick={handleOpenModal}>
-            <LogIn className="login-icon" />Login/Register
-          </button>
-        )}
         </nav>
         <Modal modalOpen={modalOpen}
-         onClose={handleCloseModal} 
-         resetToSignIn={modalOpen}
-         onLoginSuccess={() => setUserLoggedIn(true)}
-         user={user}
-         setUser={setUser}
+          onClose={handleCloseModal} 
+          resetToSignIn={modalOpen}
+          onLoginSuccess={handleLoginSuccess}
+          user={user}
+          setUser={setUser}
+          setUserName={setUserName}
           />
       </div>
     )


### PR DESCRIPTION
This PR refactors the logout functionality to use conditional logic to render either login/create account or logout using the same button. When a user is logged in, the button will change to read, "Logged in as {username}. Logout." The button will switch back to login/create account when a user clicks logout.