### PR TITLE
update default user and activities id numbers

### DIFF
--- a/mood_boost_fe/cypress/e2e/modal_spec.cy.js
+++ b/mood_boost_fe/cypress/e2e/modal_spec.cy.js
@@ -34,8 +34,8 @@ describe('Modal Spec', () => {
       });
     }).as('loginRequest');
 
-    cy.get('.username').type('testuser');
-    cy.get('.password').type('password123');
+    cy.get('.username').type('apu_nahasapeemapetilon');
+    cy.get('.password').type('securepassword1');
     cy.get('.login-submit').click();
 
     cy.wait('@loginRequest').then((interception) => {

--- a/mood_boost_fe/src/App.jsx
+++ b/mood_boost_fe/src/App.jsx
@@ -48,10 +48,10 @@ function App() {
       <div className="page-content">
       <Routes>
         <Route path="/" element={<HomePage />}/>
-        <Route path="/quote" element={<QuotePage user={user || 19} logUserActivity={logUserActivity}/>} />
-        <Route path="/joke" element={<JokePage user={user || 19} logUserActivity={logUserActivity}/>} />
-        <Route path="/breathing" element={<BreathingPage user={user || 19} logUserActivity={logUserActivity}/>} />
-        <Route path="/user" element={<UserProfile user={user || 19} />} />
+        <Route path="/quote" element={<QuotePage user={user || 47} logUserActivity={logUserActivity}/>} />
+        <Route path="/joke" element={<JokePage user={user || 47} logUserActivity={logUserActivity}/>} />
+        <Route path="/breathing" element={<BreathingPage user={user || 47} logUserActivity={logUserActivity}/>} />
+        <Route path="/user" element={<UserProfile user={user || 47} />} />
       </Routes>
       </div>
     </>

--- a/mood_boost_fe/src/BreathingPage/BreathingPage.jsx
+++ b/mood_boost_fe/src/BreathingPage/BreathingPage.jsx
@@ -8,7 +8,7 @@ function BreathingPage({user, logUserActivity}) {
   const [breathingText, setBreathingText] = useState("Inhale Positivity");
 
   function handleClick() {
-    logUserActivity(user, 6)
+    logUserActivity(user, 21)
   }
 
   const handleStartBreathing = () => {

--- a/mood_boost_fe/src/JokePage/JokePage.jsx
+++ b/mood_boost_fe/src/JokePage/JokePage.jsx
@@ -7,7 +7,7 @@ function JokePage({joke, user, logUserActivity}) {
   const [error, setError] = useState(null);
 
   function handleClick() {
-    logUserActivity(user, 4)
+    logUserActivity(user, 19)
   }
 
   useEffect(() => {

--- a/mood_boost_fe/src/QuotePage/QuotePage.jsx
+++ b/mood_boost_fe/src/QuotePage/QuotePage.jsx
@@ -6,7 +6,7 @@ function QuotePage({user, logUserActivity}) {
   const [quote, setQuote] = useState(null)
 
   function handleClick() {
-    logUserActivity(user, 5)
+    logUserActivity(user, 20)
   }
 
   function fetchQuote() {


### PR DESCRIPTION
This PR updates the default user id and activities id numbers, which are different in the deployed database. This should allow the logUserActivities function to work correctly. 