### PR TITLE
update navbar z-index so circles don't cover dropdown

### DIFF
--- a/mood_boost_fe/src/NavBar/NavBar.css
+++ b/mood_boost_fe/src/NavBar/NavBar.css
@@ -23,6 +23,7 @@ ul {
   height: 150px;
   width: 100%;
   padding: 0 60px;
+  z-index: 1000;
 }
 
 .dropdown {


### PR DESCRIPTION
This PR adds a z-index to the navbar to make sure the circles don't cover the dropdown menu. 